### PR TITLE
🗑️ Deprecate spider: minn_uhtcpc

### DIFF
--- a/city_scrapers/spiders/minn_uhtcpc.py
+++ b/city_scrapers/spiders/minn_uhtcpc.py
@@ -1,8 +1,0 @@
-from city_scrapers.mixins.minn_city import MinnCityMixin
-
-
-class MinnUhtcpcSpider(MinnCityMixin):
-    name = "minn_uhtcpc"
-    agency = "Upper Harbor Terminal Collaborative Planning Committee"
-    committee_id = 189
-    meeting_type = 2


### PR DESCRIPTION
## What's this PR do?

Deprecates the spider for minn_uhtcpc.

## Why are we doing this?

Based on my search of the agency website, it appears `Upper Harbor Terminal Collaborative Planning Committee` may no longer exist or may have been renamed. I'm deprecate this spider to avoid confusion and clean up the codebase.

![image](https://github.com/City-Bureau/city-scrapers-minn/assets/37225902/9ff7ff92-7280-40ce-96b3-24ac4e98c948)


## Steps to manually test

N/A

## Are there any smells or added technical debt to note?

N/A
