### PR TITLE
🗑️ Deprecate spider: minn_tpw_comm

### DIFF
--- a/city_scrapers/spiders/minn_tpw_comm.py
+++ b/city_scrapers/spiders/minn_tpw_comm.py
@@ -1,8 +1,0 @@
-from city_scrapers.mixins.minn_city import MinnCityMixin
-
-
-class MinnTpwCommSpider(MinnCityMixin):
-    name = "minn_tpw_comm"
-    agency = "Transportation & Public Works (TPW) Committee"
-    committee_id = 13
-    meeting_type = 1


### PR DESCRIPTION
## What's this PR do?

Deprecates the spider for minn_tpw_comm.

## Why are we doing this?

This spider appears to have been broken for some time. We're deprecating it to avoid confusion and clean up the codebase. If this spider is still needed, it can be re-implemented at a later date.

## Steps to manually test

N/A

## Are there any smells or added technical debt to note?

N/A
