### PR TITLE
🗑️ Deprecate spider: minn_recac

### DIFF
--- a/city_scrapers/spiders/minn_recac.py
+++ b/city_scrapers/spiders/minn_recac.py
@@ -1,8 +1,0 @@
-from city_scrapers.mixins.minn_city import MinnCityMixin
-
-
-class MinnRecacSpider(MinnCityMixin):
-    name = "minn_recac"
-    agency = "Racial Equity Community Advisory Committee"
-    committee_id = 175
-    meeting_type = 2


### PR DESCRIPTION
## What's this PR do?

Deprecates the spider for minn_recac.

## Why are we doing this?

This spider appears to have been broken for some time. We're deprecating it to avoid confusion and clean up the codebase. If this spider is still needed, it can be re-implemented at a later date.

## Steps to manually test

N/A

## Are there any smells or added technical debt to note?

N/A
