### PR TITLE
🗑️ Deprecate spider: minn_54lssdab

### DIFF
--- a/city_scrapers/spiders/minn_54lssdab.py
+++ b/city_scrapers/spiders/minn_54lssdab.py
@@ -1,8 +1,0 @@
-from city_scrapers.mixins.minn_city import MinnCityMixin
-
-
-class Minn54lssdabSpider(MinnCityMixin):
-    name = "minn_54lssdab"
-    agency = "54th & Lyndale Special Service District Advisory Board"
-    committee_id = 150
-    meeting_type = 2


### PR DESCRIPTION
## What's this PR do?

Deprecates the spider for minn_54lssdab.

## Why are we doing this?

This spider appears to have been broken for some time. We're deprecating it to avoid confusion and clean up the codebase. If this spider is still needed, it can be re-implemented at a later date.

## Steps to manually test

N/A

## Are there any smells or added technical debt to note?

N/A
