### PR TITLE
🕷️ Fix spider: Board of Estimate and Taxation

### DIFF
--- a/city_scrapers/mixins/minn_city.py
+++ b/city_scrapers/mixins/minn_city.py
@@ -29,7 +29,7 @@ class MinnCityMixinMeta(type):
 class MinnCityMixin(CityScrapersSpider, metaclass=MinnCityMixinMeta):
     timezone = "America/North_Dakota/Beulah"
     # scrape all meetings from one month ago
-    from_date = datetime.now() - timedelta(days=30) 
+    from_date = datetime.now() - timedelta(days=30)
     base_url = "https://lims.minneapolismn.gov/Calendar/GetCalenderList"
     to_date = ""
     links = [

--- a/city_scrapers/mixins/minn_city.py
+++ b/city_scrapers/mixins/minn_city.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import scrapy
 from city_scrapers_core.constants import BOARD, CITY_COUNCIL, COMMITTEE, NOT_CLASSIFIED
@@ -28,7 +28,8 @@ class MinnCityMixinMeta(type):
 
 class MinnCityMixin(CityScrapersSpider, metaclass=MinnCityMixinMeta):
     timezone = "America/North_Dakota/Beulah"
-    from_date = datetime.today()
+    # scrape all meetings from one month ago
+    from_date = datetime.now() - timedelta(days=30) 
     base_url = "https://lims.minneapolismn.gov/Calendar/GetCalenderList"
     to_date = ""
     links = [


### PR DESCRIPTION
## What's this PR do?

Includes meetings from one month ago with the final meeting payload.

## Why are we doing this?

This is an attempt to fix a potential bug reported by our Minn site partners. Apparently sometimes meetings show up as "cancelled" when they're not cancelled. Based on my testing, it seems like our scraper is working correctly (we derive cancellation status directly from the `Cancelled` field in the city's meeting API). My best guess at the moment is that perhaps we're not capturing last minute changes to meeting statuses by the city. We're currently requesting meetings from today and onwards. Perhaps by requesting meetings from 30 days before day and onwards, we'll capture better data.

## Steps to manually test

After installing the project using `pipenv`:

1. Activate the virtual environment:
```
pipenv shell
```
2. Run the spider:
```
scrapy crawl minn_bet -O test_output.csv
```
3. Monitor the stdout and ensure that the crawl proceeds without raising any errors. Pay attention to the final status report from scrapy.

4. Inspect `test_output.csv` to ensure the data looks valid. I suggest opening a few of the URLs under the source column of test_output.csv and comparing the data for the row with what you see on the page.

## Are there any smells or added technical debt to note?
