### PR TITLE
Pin scrapy to 2.11.1 for city_scrapers_core compat

### DIFF
--- a/.github/workflows/refresh-staging.yml
+++ b/.github/workflows/refresh-staging.yml
@@ -225,6 +225,9 @@ jobs:
         env:
           PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
 
+      - name: Install Playwright browsers
+        run: pipenv run playwright install chromium
+
       - name: Run scrapers
         run: |
           export PYTHONPATH=$(pwd):$PYTHONPATH

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -68,6 +68,9 @@ jobs:
         env:
           PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
 
+      - name: Install Playwright browsers
+        run: pipenv run playwright install chromium
+
       - name: Run scrapers
         run: |
           export PYTHONPATH=$(pwd):$PYTHONPATH

--- a/Pipfile
+++ b/Pipfile
@@ -6,11 +6,11 @@ name = "pypi"
 [packages]
 python-dateutil = "*"
 requests = "*"
-scrapy = "*"
 scrapy-sentry-errors = "1.0.0"
 city-scrapers-core = {ref = "main", git = "https://github.com/City-Bureau/city-scrapers-core.git", extras = ["azure"]}
 scrapy-wayback-middleware = "*"
 scrapy-playwright = "*"
+scrapy = "==2.11.1"
 
 [dev-packages]
 freezegun = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0e35cf1ef96d34ca797133aab1fbcba6a5f21edaf47c214c89edbc264ea0b758"
+            "sha256": "bfb3b47118a3dc351f0ee0ec8e6bfdbe87a85a339c6dd8f9a90069c81889429a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -822,12 +822,12 @@
         },
         "scrapy": {
             "hashes": [
-                "sha256:4be353d6abbb942a9f7e7614ca8b5f3d9037381176ac8d8859c8cac676e74fa0",
-                "sha256:dfbd565384fc3fffeba121f5a3a2d0899ac1f756d41432ca0879933fbfb3401d"
+                "sha256:f1edee0cd214512054c01a8d031a8d213dddb53492b02c9e66256e3efe90d175",
+                "sha256:733a039c7423e52b69bf2810b5332093d4e42a848460359c07b02ecff8f73ebe"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==2.11.2"
+            "version": "==2.11.1"
         },
         "scrapy-playwright": {
             "hashes": [


### PR DESCRIPTION
## Summary
Pin `scrapy = "==2.11.1"` to match [city-scrapers-fortx](https://github.com/City-Bureau/city-scrapers-fortx/blob/master/Pipfile). Newer scrapy versions (2.12+) pass `feed_options` as a kwarg to feed-storage classes, but `city-scrapers-core`'s `AzureBlobFeedStorage` doesn't accept it, so any pipenv-sync that resolves to scrapy 2.12+ blows up the crawl with:

```
TypeError: AzureBlobFeedStorage.__init__() got an unexpected keyword argument 'feed_options'
```

## Lock change is intentionally minimal
Only the `scrapy` entry + the Pipfile content hash. No transitive deps re-resolved.

## Already applied to staging
Merged into the `staging` branch first (commit `965af46`) so the scheduled refresh-staging workflow stops failing immediately. This PR brings the same fix to `master`.