### PR TITLE
Bump scrapy from 2.11.1 to 2.11.2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ scrapy-sentry-errors = "1.0.0"
 city-scrapers-core = {ref = "main", git = "https://github.com/City-Bureau/city-scrapers-core.git", extras = ["azure"]}
 scrapy-wayback-middleware = "*"
 scrapy-playwright = "*"
-scrapy = "==2.11.1"
+scrapy = "==2.11.2"
 
 [dev-packages]
 freezegun = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bfb3b47118a3dc351f0ee0ec8e6bfdbe87a85a339c6dd8f9a90069c81889429a"
+            "sha256": "1bae8b301671231e0b006c8fdc58c61fd2b974a2587c40da774d34c8c81de364"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -822,12 +822,12 @@
         },
         "scrapy": {
             "hashes": [
-                "sha256:f1edee0cd214512054c01a8d031a8d213dddb53492b02c9e66256e3efe90d175",
-                "sha256:733a039c7423e52b69bf2810b5332093d4e42a848460359c07b02ecff8f73ebe"
+                "sha256:4be353d6abbb942a9f7e7614ca8b5f3d9037381176ac8d8859c8cac676e74fa0",
+                "sha256:dfbd565384fc3fffeba121f5a3a2d0899ac1f756d41432ca0879933fbfb3401d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==2.11.1"
+            "version": "==2.11.2"
         },
         "scrapy-playwright": {
             "hashes": [


### PR DESCRIPTION
## Summary
Bump scrapy from 2.11.1 to 2.11.2.

scrapy 2.11.2 addresses CVE-2024-3572 (ReDoS) and CVE-2024-3574 (cookie leak on redirect), and remains compatible with city-scrapers-core's \`AzureBlobFeedStorage\` (the 2.12+ \`feed_options\` kwarg break does not affect 2.11.x).

PR #68 just pinned this repo to 2.11.1 to escape the 2.12+ \`feed_options\` break — 2.11.2 stays within the safe range while picking up the security patches.

Aligns with the version pinned in city-scrapers-atl, -det, -charnc, -cle, -colgo, -coloh, -cinoh, -kancit, -lascruc, -losca, -san-diego, -atconj, and city-scrapers.

## Lock change is intentionally minimal
Only the \`scrapy\` entry + the \`Pipfile\` content hash. No transitive deps re-resolved.

## Test plan
- [ ] CI builds + lints pass
- [ ] After merge, scheduled scraper run completes without crash