### PR TITLE
Install firefox alongside chromium in playwright workflows

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Set up playwright
         run: |
-          pipenv run playwright install chromium
+          pipenv run playwright install chromium firefox
 
       - name: Run scrapers
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Set up playwright
         run: |
-          pipenv run playwright install chromium
+          pipenv run playwright install chromium firefox
 
       - name: Check imports with isort
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Set up playwright
         run: |
-          pipenv run playwright install chromium
+          pipenv run playwright install chromium firefox
 
       - name: Run scrapers
         run: |

--- a/.github/workflows/refresh-staging.yml
+++ b/.github/workflows/refresh-staging.yml
@@ -226,7 +226,7 @@ jobs:
           PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
 
       - name: Install Playwright browsers
-        run: pipenv run playwright install chromium
+        run: pipenv run playwright install chromium firefox
 
       - name: Run scrapers
         run: |

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -69,7 +69,7 @@ jobs:
           PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
 
       - name: Install Playwright browsers
-        run: pipenv run playwright install chromium
+        run: pipenv run playwright install chromium firefox
 
       - name: Run scrapers
         run: |


### PR DESCRIPTION
## Summary

- The `MinnCityMixin` (used by all Minneapolis LIMS factory spiders, e.g. `minn_audit_co`, `minn_bac`, `minn_char_co`, `minn_epb`) sets `PLAYWRIGHT_BROWSER_TYPE: "firefox"` in `city_scrapers/mixins/minn_city.py:52`, but all 5 workflows only run `playwright install chromium`. As a result, those spiders fail in CI with:
  > `BrowserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/firefox-1511/firefox/firefox`
- This PR updates all 5 workflows (`ci.yml`, `cron.yml`, `staging.yml`, `archive.yml`, `refresh-staging.yml`) to install both `chromium firefox` so each spider can use the browser its mixin requests.

## Test plan

- [ ] CI passes on this PR (verifies `ci.yml` change works)
- [ ] After merge, monitor the next scheduled `cron.yml` / `staging.yml` run and confirm `minn_*` LIMS spiders launch firefox successfully (no `Executable doesn't exist` errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)