### PR TITLE
Sync master Pipfile + lock with staging (restore scrapy 2.11.2)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,13 +6,13 @@ name = "pypi"
 [packages]
 python-dateutil = "*"
 requests = "*"
+scrapy = "==2.11.2"
 scrapy-sentry-errors = "1.0.0"
 city-scrapers-core = {ref = "main", git = "https://github.com/City-Bureau/city-scrapers-core.git", extras = ["azure"]}
 scrapy-wayback-middleware = "*"
 scrapy-playwright = "*"
 icalendar = "*"
 recurring-ical-events = "*"
-scrapy = "==2.11.2"
 
 [dev-packages]
 freezegun = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1bae8b301671231e0b006c8fdc58c61fd2b974a2587c40da774d34c8c81de364"
+            "sha256": "5f066a4d95b575e614ac03df8ea3d363e79cf19dd7cb35a6910e3eecfe02c01d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -935,12 +935,12 @@
         },
         "scrapy": {
             "hashes": [
-                "sha256:c7b8fc8d2c51a39d52f6025bdd7e9c714e43f97afd300e8c44157cf7a05c0c9e",
-                "sha256:ff47379299699f1fcc7bc1d404754306f04371d0822e077c2857777d60743e07"
+                "sha256:4be353d6abbb942a9f7e7614ca8b5f3d9037381176ac8d8859c8cac676e74fa0",
+                "sha256:dfbd565384fc3fffeba121f5a3a2d0899ac1f756d41432ca0879933fbfb3401d"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.10'",
-            "version": "==2.15.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.11.2"
         },
         "scrapy-playwright": {
             "hashes": [


### PR DESCRIPTION
## Summary

- PR #66 re-resolved `Pipfile.lock` on master and bumped scrapy from 2.11.2 → 2.15.2.
- Scrapy 2.12+ passes `feed_options` to feed storage classes, which `city-scrapers-core`'s `AzureBlobFeedStorage` doesn't accept — every spider in the post-merge Cron run fails at startup with `TypeError: AzureBlobFeedStorage.__init__() got an unexpected keyword argument 'feed_options'`.
- `staging` was unaffected — staging already had scrapy `==2.11.2` along with `icalendar` and `recurring-ical-events` locked correctly. This PR copies `Pipfile` + `Pipfile.lock` from `origin/staging` so master matches the validated state.

## Diff scope

Surgical — 6 insertions / 6 deletions:
- `Pipfile.lock`: scrapy entry (`==2.15.2` → `==2.11.2`) + meta hash
- `Pipfile`: one-line reorder (`scrapy = "==2.11.2"` moved up alongside other direct deps)

No transitive deps re-resolved.

## Test plan

- [ ] CI green
- [ ] After merge to `master`, re-trigger `Cron` and confirm spiders start without the `feed_options` TypeError
- [ ] Verify `meetings-feed-minn/latest.json` is updated by the new run